### PR TITLE
fix indention issues caused by extra leading spaces

### DIFF
--- a/gen.js
+++ b/gen.js
@@ -17,13 +17,14 @@ fs.readdir("laws", function(err, laws) {
 			if(element[0] == "第") { // 章
 				return "\\subsection*{" + element + "}";
 			}
+			var text = element.replace(/^\s+/, '');
 			switch(element.search(/\S/) / 2){
 				case 1: // 條
-					return "\\textbf{" + element + "}\\\\";
+					return "\\textbf{" + text + "}\\\\";
 				case 2: // 項
-					return "\\hspace*{9pt} " + element + "\\\\";
+					return "\\hspace*{10pt}" + text + "\\\\";
 				case 3: // 款
-					return "\\hspace*{18pt} " + element + "\\\\";
+					return "\\hspace*{20pt}" + text + "\\\\";
 				default:
 					return "";
 			}

--- a/gen.js
+++ b/gen.js
@@ -22,9 +22,9 @@ fs.readdir("laws", function(err, laws) {
 				case 1: // 條
 					return "\\textbf{" + text + "}\\\\";
 				case 2: // 項
-					return "\\hspace*{10pt}" + text + "\\\\";
+					return "\\hspace*{1em}" + text + "\\\\";
 				case 3: // 款
-					return "\\hspace*{20pt}" + text + "\\\\";
+					return "\\hspace*{2em}" + text + "\\\\";
 				default:
 					return "";
 			}


### PR DESCRIPTION
![before](https://cloud.githubusercontent.com/assets/5269414/13198002/20a8fc2e-d838-11e5-9af9-977d1980450c.jpg)
1. 段落起始行開頭的空白會造成意外的縮排效果，應在產生 tex 檔時去除。
2. 實際測試發現這樣的修正不夠， `9pt` 的縮排無法使每行縮排恰好一個字元，故改用 `em` 作為縮排單位。

套用後：
![after](https://cloud.githubusercontent.com/assets/5269414/13198003/20af38dc-d838-11e5-9964-e615de3391e4.jpg)
